### PR TITLE
Feature/container attach add no move cursor

### DIFF
--- a/src/command_modules/azure-cli-container/HISTORY.rst
+++ b/src/command_modules/azure-cli-container/HISTORY.rst
@@ -2,6 +2,10 @@
 
 Release History
 ===============
+0.3.18
+++++++
+* Added --no-move-cursor to 'az container log' and 'az container attach' to prevent duplicate lines when piping
+
 0.3.17
 ++++++
 * Minor fixes.

--- a/src/command_modules/azure-cli-container/README.rst
+++ b/src/command_modules/azure-cli-container/README.rst
@@ -164,6 +164,7 @@ Commands to tail the logs of a Azure container group
 
     Arguments
         --container-name   : The container name to tail the logs.
+        --no-move-cursor   : Do not move cursor up, useful when piping.
 
     Resource Id Arguments
         --ids              : One or more resource IDs (space-delimited). If provided, no other 'Resource
@@ -275,6 +276,7 @@ Commands to attach to a container in a container group
     Arguments
         --container-name   : The container to attach to. If omitted, the first container in the
                             container group will be chosen.
+        --no-move-cursor   : Do not move cursor up, useful when piping.
 
     Resource Id Arguments
         --ids              : One or more resource IDs (space delimited). If provided, no other 'Resource

--- a/src/command_modules/azure-cli-container/azure/cli/command_modules/container/_params.py
+++ b/src/command_modules/azure-cli-container/azure/cli/command_modules/container/_params.py
@@ -129,3 +129,6 @@ def load_arguments(self, _):
 
     with self.argument_context('container attach') as c:
         c.argument('container_name', help='The container to attach to. If omitted, the first container in the container group will be chosen')
+        c.argument('no_move_cursor', options_list=['--no-move-cursor'], help='Do not move cursor up, useful when piping', action='store_true')
+
+        

--- a/src/command_modules/azure-cli-container/azure/cli/command_modules/container/_params.py
+++ b/src/command_modules/azure-cli-container/azure/cli/command_modules/container/_params.py
@@ -117,6 +117,7 @@ def load_arguments(self, _):
     with self.argument_context('container logs') as c:
         c.argument('container_name', help='The container name to tail the logs. If omitted, the first container in the container group will be chosen')
         c.argument('follow', help='Indicate to stream the tailing logs', action='store_true')
+        c.argument('no_move_cursor', options_list=['--no-move-cursor'], help='Do not move cursor up, useful when piping', action='store_true')
 
     with self.argument_context('container export') as c:
         c.argument('file', options_list=['--file', '-f'], help="The file path to export the container group.")
@@ -130,5 +131,3 @@ def load_arguments(self, _):
     with self.argument_context('container attach') as c:
         c.argument('container_name', help='The container to attach to. If omitted, the first container in the container group will be chosen')
         c.argument('no_move_cursor', options_list=['--no-move-cursor'], help='Do not move cursor up, useful when piping', action='store_true')
-
-        

--- a/src/command_modules/azure-cli-container/setup.py
+++ b/src/command_modules/azure-cli-container/setup.py
@@ -14,7 +14,7 @@ except ImportError:
     logger.warn("Wheel is not available, disabling bdist_wheel hook")
     cmdclass = {}
 
-VERSION = "0.3.17"
+VERSION = "0.3.18"
 
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',


### PR DESCRIPTION
I've added `--no-move-cursor` to make piping easier and less messy, no duplicate lines. We needed this to pipe the container attach/log output to another application

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR has modified HISTORY.rst describing any customer-facing, functional changes. Note that this does not include changes only to help content. (see [Modifying change log](https://github.com/Azure/azure-cli/tree/master/doc/authoring_command_modules#modify-change-log)).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).
